### PR TITLE
Add automated tests through AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,34 @@
+clone_depth: 1
+platform:
+  - x64
+services:
+  - mysql
+  - mssql2016
+environment:
+  MYSQL_VERSION: 5.7
+  MYSQL_SERVICE: MySQL57
+  MYSQL_USER: root
+  MYSQL_PWD: 'Password12!'
+  MSSQL_VERSION: SQL2016
+  MSSQL_USER: sa
+  MSSQL_PWD: 'Password12!'
+  MSSQL_BAK: WideWorldImporters-Standard.bak
+  MSSQL_DATABASE: WideWorldImporters
+  MSSQL_TABLE: Sales.Customers
+init:
+  - ps: $env:DIR="$env:APPVEYOR_BUILD_FOLDER\.appveyor\"
+  - ps: $env:PATH="$env:PATH;$env:APPVEYOR_BUILD_FOLDER\;$env:DIR;$env:PROGRAMFILES\MySQL\MySQL Server $env:MYSQL_VERSION\bin\"
+install:
+  - ps: start_mssql.ps1 $env:MSSQL_VERSION
+  - ps: start_mysql.ps1 $env:MYSQL_VERSION $env:MYSQL_SERVICE
+  - ps: Invoke-WebRequest https://github.com/Microsoft/sql-server-samples/releases/download/wide-world-importers-v1.0/$env:MSSQL_BAK -OutFile $env:DIR\$env:MSSQL_BAK
+  - ps: replace_all.ps1 $env:DIR\import_wwi.sql C:\WideWorldImporters\ $env:DIR
+  - cmd: sqlcmd -i %DIR%\import_wwi.sql
+build_script:
+  - ps: GetMsSqlDump.ps1 -db $env:MSSQL_DATABASE -table $env:MSSQL_TABLE -username $env:MSSQL_USER -password "$env:MSSQL_PWD" -pointfromtext -file $env:DIR\$env:MSSQL_TABLE.sql
+  - cmd: mysql --host=localhost --user=%MYSQL_USER% < %DIR%\mysql_create_table.sql
+  - cmd: mysql --host=localhost --user=%MYSQL_USER% %MSSQL_DATABASE% < %DIR%\%MSSQL_TABLE%.sql
+artifacts:
+  - path: '**\$(MSSQL_TABLE).sql'
+    name: $(MSSQL_TABLE).sql
+    type: File

--- a/.appveyor/import_wwi.sql
+++ b/.appveyor/import_wwi.sql
@@ -1,0 +1,7 @@
+USE [master]
+RESTORE DATABASE [WideWorldImporters] FROM 
+DISK = N'C:\WideWorldImporters\WideWorldImporters-Standard.bak' WITH
+MOVE N'WWI_Primary' TO N'C:\WideWorldImporters\WideWorldImporters.mdf',  
+MOVE N'WWI_UserData' TO N'C:\WideWorldImporters\WideWorldImporters_UserData.ndf',  
+MOVE N'WWI_Log' TO N'C:\WideWorldImporters\WideWorldImporters.ldf'
+GO

--- a/.appveyor/mysql_create_table.sql
+++ b/.appveyor/mysql_create_table.sql
@@ -1,0 +1,37 @@
+CREATE DATABASE WideWorldImporters;
+
+USE WideWorldImporters;
+
+CREATE TABLE Sales_Customers (
+	CustomerID int NOT NULL PRIMARY KEY,
+	CustomerName nvarchar(100) NOT NULL,
+	BillToCustomerID int NOT NULL,
+	CustomerCategoryID int NOT NULL,
+	BuyingGroupID int,
+	PrimaryContactPersonID int NOT NULL,
+	AlternateContactPersonID int,
+	DeliveryMethodID int NOT NULL,
+	DeliveryCityID int NOT NULL,
+	PostalCityID int NOT NULL,
+	CreditLimit decimal(18,2),
+	AccountOpenedDate date NOT NULL,
+	StandardDiscountPercentage decimal(18,3) NOT NULL,
+	IsStatementSent boolean NOT NULL,
+	IsOnCreditHold boolean NOT NULL,
+	PaymentDays int NOT NULL,
+	PhoneNumber nvarchar(20) NOT NULL,
+	FaxNumber nvarchar(20) NOT NULL,
+	DeliveryRun nvarchar(5),
+	RunPosition nvarchar(5),
+	WebsiteURL nvarchar(256) NOT NULL,
+	DeliveryAddressLine1 nvarchar(60) NOT NULL,
+	DeliveryAddressLine2 nvarchar(60),
+	DeliveryPostalCode nvarchar(10) NOT NULL,
+	DeliveryLocation geometry,
+	PostalAddressLine1 nvarchar(60) NOT NULL,
+	PostalAddressLine2 nvarchar(60),
+	PostalPostalCode nvarchar(10) NOT NULL,
+	LastEditedBy int NOT NULL,
+	ValidFrom datetime NOT NULL,
+	ValidTo datetime NOT NULL
+);

--- a/.appveyor/replace_all.ps1
+++ b/.appveyor/replace_all.ps1
@@ -1,0 +1,5 @@
+$file = $args[0]
+$search = $args[1]
+$replace = $args[2]
+$new_text = ([System.IO.File]::ReadAllText($file)).Replace($search, $replace)
+[System.IO.File]::WriteAllText($file, $new_text)

--- a/.appveyor/start_mssql.ps1
+++ b/.appveyor/start_mssql.ps1
@@ -1,0 +1,27 @@
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement") | Out-Null
+
+$instancename = $args[0];
+$computerName = $env:COMPUTERNAME
+$smo = 'Microsoft.SqlServer.Management.Smo.'
+$wmi = New-Object ($smo + 'Wmi.ManagedComputer')
+
+$uri = "ManagedComputer[@Name='$computerName']/ ServerInstance[@Name='$instancename']/ServerProtocol[@Name='Tcp']"
+$Tcp = $wmi.GetSmoObject($uri)
+foreach ($ipAddress in $Tcp.IPAddresses)
+{
+    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
+    $ipAddress.IPAddressProperties["TcpPort"].Value = "1433"
+}
+$Tcp.Alter()
+
+# Enable named pipes
+$uri = "ManagedComputer[@Name='$computerName']/ ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='Np']"
+$Np = $wmi.GetSmoObject($uri)
+$Np.IsEnabled = $true
+$Np.Alter()
+
+Stop-Service SQLBrowser
+Stop-Service "MSSQL`$$instancename"
+Start-Service SQLBrowser
+Start-Service "MSSQL`$$instancename"

--- a/.appveyor/start_mysql.ps1
+++ b/.appveyor/start_mysql.ps1
@@ -1,0 +1,4 @@
+$mysql_version = $args[0]
+$mysql_service = $args[1]
+replace_all.ps1 "C:\ProgramData\MySQL\MySQL Server $mysql_version\my.ini" "# enable-named-pipe" "enable-named-pipe"
+Restart-Service $mysql_service

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ All switched **must** be prefixed with a single hyphen.  e.g. `-append -overwrit
 | `append` |	Dump will be appended to the file specified by file parameter. |
 | `overwrite` | Dump will overwrite the file specified by file parameter. |
 | `noidentity` | Identity values won't be dumped. This way you can add the rows to a table with the same identity column specification. If no identity column exists in the table, the switch will be ignored. |
+| `allowdots` | Disable the replacement of dots `.` in a table name with underscores `_`. |
+| `pointfromtext` | Use PointFromText attempts to convert `SqlGeography` `POINT(x y)` values using `PointFromText('POINT(x y)')` WKT (well-known-text) conversion |
 | `debug` |	Prints way more characters to your screen than you'd like to. If something didn’t work in the way you expected, or you want to submit a bug, run your statement with the debug switch. |
 | `help` or `?` |	Prints this short help. Ignores all other parameters. |
 


### PR DESCRIPTION
Adds automated builds through AppVeyor.

Some problems that needed to be fixed before we could use Microsoft's `WorldWideImporters` sample database:
* Tables can't have dots in the names, e.g. `Sales.Customers`, closes #6 by adding new `-allowdots` flag.  Behavior is toggled to "off", by default -- dots in table names are not allowed.
* Geographical data can't be used out of the box with `POINT(x y)` due to unsupported decimal precision.  Closes #4 by adding new `-pointfromtext` flag, which wraps the `POINT(float, float)` in a `PointFromText(...)` MySQL helper function.  This has the side-effect of making the point data in a binary format, so it's off by default.
* Microsoft SQL `datetime2` fields are causing an overflow.  Closes #5 by preventing the overflow on the default timestamp edge-case.
* AppVeyor wasn't handling the Exceptions properly.  Added `$ErrorActionPreference = "Stop"` to the top of the script for better error handling.