### PR TITLE
Fix added because somehow the $server variable contained a space...

### DIFF
--- a/GetMsSqlDump.ps1
+++ b/GetMsSqlDump.ps1
@@ -118,6 +118,8 @@ if ($IsMacOS -or $IsLinux) {
     }
 }
 
+$server = $server.Replace(" ", ",")  # Fix added because somehow $server contained a space between the server name and port.
+
 #-----------------------------------------------------------[Functions]------------------------------------------------------------
 
 # Formats the cell in parameter into a string, based on its type


### PR DESCRIPTION
between the server name and port, which would cause `conn.Open` to hang and terminate with an error.